### PR TITLE
Add telegram-webapp-auth library link: https://github.com/swimmwatch/telegram-webapp-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ They can take advantage of many features out of the box, including seamless auth
 - [Typings for Telegram Mini Apps](https://github.com/DavisDmitry/telegram-webapps/tree/master) - TypeScript typings for the WebApp API.
 - [init-data-golang](https://github.com/Telegram-Mini-Apps/init-data-golang) - Init data validation utilities for Go.
 - [react-telegram-web-app](https://github.com/vkruglikov/react-telegram-web-app) - React hooks and components for building the WebApp API.
+- [telegram-webapp-auth](https://github.com/swimmwatch/telegram-webapp-auth) - Init data validation utilities for Python.
 
 ## Templates
 


### PR DESCRIPTION
Hi there! 👋

I recently created a small library for Python [telegram-webapp-auth](https://github.com/swimmwatch/telegram-webapp-auth) to simplify Init Data validation (analog [init-data-golang](https://github.com/Telegram-Mini-Apps/init-data-golang)).

I’d love to add it to the [awesome-telegram-mini-apps](https://github.com/mrgrecha/awesome-telegram-mini-apps) repository.